### PR TITLE
Add four peer docker compose file

### DIFF
--- a/docker-compose/base/peer-secure-base.yaml
+++ b/docker-compose/base/peer-secure-base.yaml
@@ -1,17 +1,12 @@
 peer-secure-base:
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
-  ports:
-    - "7050:7050"
-    - "7051:7051"
-    - "7053:7053"
   environment:
     - CORE_PEER_DISCOVERY_PERIOD=300s
     - CORE_PEER_DISCOVERY_TOUCHPERIOD=301s
     - CORE_PEER_ADDRESSAUTODETECT=true
     - CORE_VM_ENDPOINT= unix:///var/run/docker.sock
     - CORE_LOGGING_LEVEL=DEBUG
-    - CORE_PEER_ID=vp0
     - CORE_PEER_PKI_ECA_PADDR=membersrvc:7054
     - CORE_PEER_PKI_TCA_PADDR=membersrvc:7054
     - CORE_PEER_PKI_TLSCA_PADDR=membersrvc:7054

--- a/docker-compose/four-peer-ca-x86.yaml
+++ b/docker-compose/four-peer-ca-x86.yaml
@@ -1,0 +1,73 @@
+membersrvc:
+  image: hyperledger/fabric-membersrvc:x86_64-0.6.0-preview
+  extends:
+    file: base/membersrvc.yaml
+    service: membersrvc
+
+vp0:
+  image: hyperledger/fabric-peer:x86_64-0.6.0-preview
+  extends:
+    file: base/peer-secure-base.yaml
+    service: peer-secure-base
+  ports:
+    - "7050:7050"
+    - "7051:7051"
+    - "7053:7053"
+  environment:
+    - CORE_PEER_ID=vp0
+    - CORE_SECURITY_ENROLLID=test_vp0
+    - CORE_SECURITY_ENROLLSECRET=MwYpmSRjupbT
+  links:
+    - membersrvc
+
+vp1:
+  image: hyperledger/fabric-peer:x86_64-0.6.0-preview
+  extends:
+    file: base/peer-secure-base.yaml
+    service: peer-secure-base
+  ports:
+    - "8050:7050"
+    - "8051:7051"
+    - "8053:7053"
+  environment:
+    - CORE_PEER_DISCOVERY_ROOTNODE=vp0:7051
+    - CORE_PEER_ID=vp1
+    - CORE_SECURITY_ENROLLID=test_vp1
+    - CORE_SECURITY_ENROLLSECRET=5wgHK9qqYaPy
+  links:
+    - vp0
+
+vp2:
+  image: hyperledger/fabric-peer:x86_64-0.6.0-preview
+  extends:
+    file: base/peer-secure-base.yaml
+    service: peer-secure-base
+  ports:
+    - "9050:7050"
+    - "9051:7051"
+    - "9053:7053"
+  environment:
+    - CORE_PEER_DISCOVERY_ROOTNODE=vp0:7051
+    - CORE_PEER_ID=vp2
+    - CORE_SECURITY_ENROLLID=test_vp2
+    - CORE_SECURITY_ENROLLSECRET=vQelbRvja7cJ
+  links:
+    - vp0
+
+vp3:
+  image: hyperledger/fabric-peer:x86_64-0.6.0-preview
+  extends:
+    file: base/peer-secure-base.yaml
+    service: peer-secure-base
+  ports:
+    - "10050:7050"
+    - "10051:7051"
+    - "10053:7053"
+  environment:
+    - CORE_PEER_DISCOVERY_ROOTNODE=vp0:7051
+    - CORE_PEER_ID=vp3
+    - CORE_SECURITY_ENROLLID=test_vp3
+    - CORE_SECURITY_ENROLLSECRET=9LKqKH5peurL
+  links:
+    - vp0
+

--- a/docker-compose/four-peer-ca-x86.yaml
+++ b/docker-compose/four-peer-ca-x86.yaml
@@ -35,6 +35,7 @@ vp1:
     - CORE_SECURITY_ENROLLID=test_vp1
     - CORE_SECURITY_ENROLLSECRET=5wgHK9qqYaPy
   links:
+    - membersrvc
     - vp0
 
 vp2:
@@ -52,6 +53,7 @@ vp2:
     - CORE_SECURITY_ENROLLID=test_vp2
     - CORE_SECURITY_ENROLLSECRET=vQelbRvja7cJ
   links:
+    - membersrvc
     - vp0
 
 vp3:
@@ -69,5 +71,6 @@ vp3:
     - CORE_SECURITY_ENROLLID=test_vp3
     - CORE_SECURITY_ENROLLSECRET=9LKqKH5peurL
   links:
+    - membersrvc
     - vp0
 

--- a/docker-compose/single-peer-ca-x86.yaml
+++ b/docker-compose/single-peer-ca-x86.yaml
@@ -9,8 +9,12 @@ vp:
   extends:
     file: base/peer-secure-base.yaml
     service: peer-secure-base
+  ports:
+    - "7050:7050"
+    - "7051:7051"
+    - "7053:7053"
   environment:
-    - CORE_PEER_ID=vp
+    - CORE_PEER_ID=vp0
     - CORE_SECURITY_ENROLLID=vp
     - CORE_SECURITY_ENROLLSECRET=f3489fy98ghf
   links:


### PR DESCRIPTION
This PR adds a docker compose yaml file that brings up a 4 peer network.

It also modifies the base yaml file to move peer specific information in the main yaml files.
