### PR TITLE
Barry

### DIFF
--- a/docker-compose/base/membersrvc.yaml
+++ b/docker-compose/base/membersrvc.yaml
@@ -1,5 +1,3 @@
-version: '2'
-services:
   membersrvc:
     ports:
     - "7054:7054"

--- a/docker-compose/base/peer-secure-base.yaml
+++ b/docker-compose/base/peer-secure-base.yaml
@@ -1,5 +1,3 @@
-version: '2'
-services:
   peer-secure-base:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose/base/peer-secure-pbft-base.yaml
+++ b/docker-compose/base/peer-secure-pbft-base.yaml
@@ -1,5 +1,3 @@
-version: '2'
-services:
   peer-secure-pbft-base:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose/baseimage/Dockerfile
+++ b/docker-compose/baseimage/Dockerfile
@@ -1,1 +1,3 @@
-FROM hyperledger/fabric-baseimage:${ARCH_TAG}
+FROM ubuntu
+ARG base
+ONBUILD ADD hyperledger/fabric-baseimage:$base

--- a/docker-compose/baseimage/Dockerfile
+++ b/docker-compose/baseimage/Dockerfile
@@ -1,3 +1,0 @@
-FROM ubuntu
-ARG base
-ONBUILD ADD hyperledger/fabric-baseimage:$base

--- a/docker-compose/four-peer-ca.yaml
+++ b/docker-compose/four-peer-ca.yaml
@@ -1,6 +1,3 @@
-version: '2'
-services:
-
   membersrvc:
     image: hyperledger/fabric-membersrvc:${ARCH_TAG}
     extends:

--- a/docker-compose/four-peer-ca.yaml
+++ b/docker-compose/four-peer-ca.yaml
@@ -1,11 +1,5 @@
 version: '2'
 services:
-  baseimage:
-    build:
-      context: ./baseimage
-      args:
-        base: ${BASE_TAG}
-    image: hyperledger/fabric-baseimage:latest
 
   membersrvc:
     image: hyperledger/fabric-membersrvc:${ARCH_TAG}

--- a/docker-compose/four-peer-ca.yaml
+++ b/docker-compose/four-peer-ca.yaml
@@ -1,7 +1,10 @@
 version: '2'
 services:
   baseimage:
-    build: ./baseimage
+    build:
+      context: ./baseimage
+      args:
+        base: ${BASE_TAG}
     image: hyperledger/fabric-baseimage:latest
 
   membersrvc:

--- a/docker-compose/setenv.sh
+++ b/docker-compose/setenv.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
-if [ $(uname -m) == "x86_64" ]; then
-    export ARCH_TAG="x86_64-0.6.1-preview"
-    export BASE_TAG="x86_64-0.0.11"
-elif [ $(uname -m) == "s390x" ]; then
-    export ARCH_TAG="s390x-0.6.1-preview"
-    export BASE_TAG="s390x-0.0.11"
-elif [ $(uname -m) == "ppc64le" ]; then
-    export ARCH_TAG="ppc64le-0.6.1-preview"
-    export BASE_TAG="ppc64le-0.0.11"
-else
-    export ARCH_TAG="unknownarch"
-    export BASE_TAG="unknownarch"
-    echo "WARNING:" $(uname -m) "is an unsupported architecture"
+
+arch=`uname -m`
+
+case $arch in
+"x86_64")
+      export ARCH_TAG="x86_64-0.6.1-preview"
+  ;;
+"s390x")
+      export ARCH_TAG="s390x-0.6.1-preview"
+  ;;
+"ppc64le")
+      export ARCH_TAG="ppc64le-0.6.1-preview"       
+  ;;
+*)
+  echo "No Architectural Images Available for Architecture: $arch - Please call ibm service"
+  return 
+  ;;
+esac
+
+docker pull hyperledger/fabric-peer:${ARCH_TAG} 
+if [ $? -ne 0 ]; then
+   echo "docker pull failed to peer image"
+   return 
 fi
+docker tag hyperledger/fabric-peer:${ARCH_TAG} hyperledger/fabric-baseimage:latest
+
+if [ $? -ne 0 ]; then
+   echo "docker tag failed"
+   return
+fi
+

--- a/docker-compose/setenv.sh
+++ b/docker-compose/setenv.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-if [ $(uname -m) == "x86_64" ] || [ $(uname -m) == "x86_32" ]; then
+if [ $(uname -m) == "x86_64" ]; then
     export ARCH_TAG="x86_64-0.6.1-preview"
+    export BASE_TAG="x86_64-0.0.11"
 elif [ $(uname -m) == "s390x" ]; then
     export ARCH_TAG="s390x-0.6.1-preview"
+    export BASE_TAG="s390x-0.0.11"
 elif [ $(uname -m) == "ppc64le" ]; then
     export ARCH_TAG="ppc64le-0.6.1-preview"
+    export BASE_TAG="ppc64le-0.0.11"
 else
     export ARCH_TAG="unknownarch"
+    export BASE_TAG="unknownarch"
+    echo "WARNING:" $(uname -m) "is an unsupported architecture"
 fi

--- a/docker-compose/setenv.sh
+++ b/docker-compose/setenv.sh
@@ -23,8 +23,8 @@ if [ $? -ne 0 ]; then
    echo "docker pull failed to peer image"
    return 
 fi
-docker tag hyperledger/fabric-peer:${ARCH_TAG} hyperledger/fabric-baseimage:latest
 
+docker tag hyperledger/fabric-peer:${ARCH_TAG} hyperledger/fabric-baseimage:latest
 if [ $? -ne 0 ]; then
    echo "docker tag failed"
    return

--- a/docker-compose/single-peer-ca.yaml
+++ b/docker-compose/single-peer-ca.yaml
@@ -1,5 +1,3 @@
-version: '2'
-services:
   membersrvc:
     image: hyperledger/fabric-membersrvc:${ARCH_TAG}
     extends:

--- a/docker-compose/single-peer-ca.yaml
+++ b/docker-compose/single-peer-ca.yaml
@@ -1,12 +1,5 @@
 version: '2'
 services:
-  baseimage:
-    build:
-      context: ./baseimage
-      args:
-        base: ${BASE_TAG}
-    image: hyperledger/fabric-baseimage:latest
-
   membersrvc:
     image: hyperledger/fabric-membersrvc:${ARCH_TAG}
     extends:

--- a/docker-compose/single-peer-ca.yaml
+++ b/docker-compose/single-peer-ca.yaml
@@ -1,5 +1,12 @@
 version: '2'
 services:
+  baseimage:
+    build:
+      context: ./baseimage
+      args:
+        base: ${BASE_TAG}
+    image: hyperledger/fabric-baseimage:latest
+
   membersrvc:
     image: hyperledger/fabric-membersrvc:${ARCH_TAG}
     extends:

--- a/dockerfiles/x86/peer/Dockerfile
+++ b/dockerfiles/x86/peer/Dockerfile
@@ -1,1 +1,0 @@
-FROM hyperledger/fabric-peer:x86_64-0.6.0-preview

--- a/dockerfiles/x86/peer/README.md
+++ b/dockerfiles/x86/peer/README.md
@@ -1,1 +1,0 @@
-Hyperledger fabric peer image for x86_64 platforms


### PR DESCRIPTION
 Hi Gari,
This works, but I doubt you will like that there is a docker pull/tag in the setenv.sh.   Latitia is working with Mihir to have the docker-compose use logic similiar to:
services:
  baseimage:
    build: ./baseimage
    image: hyperledger/fabric-baseimage:latest

...however, we are hitting glitches when building the image and running the deploy.  

You were right in the baseimage can be a tag of the peer image.  I'm guessing holding off on merging this one is best and let's see where Latitia and Mihir get with a more eloquent solution.
