### PR TITLE
Removed latest tag

### DIFF
--- a/docker-compose/single-peer-ca.yaml
+++ b/docker-compose/single-peer-ca.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
   baseimage:
     build: ./baseimage
-    image: hyperledger/fabric-baseimage:latest
+    image: hyperledger/fabric-baseimage
 
   membersrvc:
     image: ibmblockchain/fabric-membersrvc:${ARCH_TAG}


### PR DESCRIPTION
The latest tag is removed from the hyperledger/fabrci-baseimage, 
Ref: https://hub.docker.com/r/hyperledger/fabric-baseimage/